### PR TITLE
feat: create ServiceResponse helper to standardize service layer retu…

### DIFF
--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -26,8 +26,8 @@ class UserController
 
         $userService = UserService::create($body);
 
-        if ($userService['error'] !== false) {
-            return $this->httpResponse->badRequest($userService['error']);
+        if ($userService['error']) {
+        return $this->httpResponse->badRequest($userService['message']);
         }
 
         $this->httpResponse->created($userService);

--- a/src/Services/UserService.php
+++ b/src/Services/UserService.php
@@ -6,6 +6,7 @@ use App\Utils\Validator;
 use Exception;
 use PDOException;
 use App\Models\User;
+use App\Utils\ServiceResponse;
 
 class UserService
 {
@@ -22,39 +23,29 @@ class UserService
 
             $user = User::save($fields);
 
-            if (!$user) return ['error' => 'Sorry, we could not create your account.',];    
+            if (!$user) return ServiceResponse::error('Sorry, we could not create your account.');  
 
-            return [
-                'error' => false,
-                'success' => true,
-                'message' => 'User created successfully!'
-                ];
+            return ServiceResponse::success('User created successfully.', [
+                'user' => $user
+            ]);
 
         }
         catch (PDOException $e) {
 
             if ($e->errorInfo[1] == 1044) {
-                    return [
-                        'error' => 'User does not have permission to access the database.'
-                    ];
+                    return ServiceResponse::error('User does not have permission to access the database.');
                 }
                 
             if ($e->errorInfo[1] == 1049) {
-                return [
-                    'error' => 'Database does not exist.'
-                    ];
+                return ServiceResponse::error('Database does not exist.');
                 }
                 
             if ($e->errorInfo[1] == 1062) {
-                return [
-                    'error' => 'Sorry, user already exists.'
-                    ];
+                return ServiceResponse::error('Sorry, user already exists.');
                 }
 
             if ($e->errorInfo[1] == 1045) {
-                return [
-                    'error' => 'User or password is incorrect.'
-                    ];
+                return ServiceResponse::error('User or password is incorrect.');
                 }
                 
             return [

--- a/src/Utils/ServiceResponse.php
+++ b/src/Utils/ServiceResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Utils;
+
+class ServiceResponse
+{
+    public static function success(string $message = '', array $data = []): array
+    {
+        return [
+            'error' => false,
+            'success' => true,
+            'message' => $message,
+            'data' => $data
+        ];
+    }
+
+    public static function error(string $message): array
+    {
+        return [
+            'error' => true,
+            'success' => false,
+            'message' => $message
+        ];
+    }
+}


### PR DESCRIPTION
- Added `ServiceResponse.php` in the `App\Utils` directory
- Implemented two static methods:
  - `ServiceResponse::success(string $message = '', array $data = [])`
  - `ServiceResponse::error(string $message)`
- Refactored `UserService::create()` to utilize the `ServiceResponse` helper